### PR TITLE
Add support for building FreeBSD binaries on GitHub Actions

### DIFF
--- a/.github/workflows/build_binary.yml
+++ b/.github/workflows/build_binary.yml
@@ -3,11 +3,11 @@ name: Build and publish tdlibjson linux binaries
 on:
   push:
     tags:
-      - 'aiotdlib_*'
+      - "aiotdlib_*"
 
 jobs:
-  build:
-    name: Set up Earthly and run build
+  build_linux:
+    name: Build Linux x86_64
     runs-on: ubuntu-latest
     steps:
       - name: Set up QEMU
@@ -26,3 +26,32 @@ jobs:
         uses: softprops/action-gh-release@v1
         with:
           files: build/libtdjson_linux_amd64.so
+
+  build_freebsd:
+    name: Build FreeBSD x86_64
+    runs-on: macos-12
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v3
+        with:
+          path: tdlib
+
+      - name: Build TDLib
+        uses: vmactions/freebsd-vm@v0
+        with:
+          release: 13.1
+          mem: 2048
+          prepare: |
+            pkg update
+            pkg install -y llvm cmake ninja gperf openssl lzlib gperf
+          run: |
+            mkdir ./build
+            cmake -DCMAKE_BUILD_TYPE=Release -S ./tdlib -B ./build -G Ninja
+            cmake --build ./build --target tdjson --parallel
+            strip --strip-all ./build/libtdjson.so.*
+            mv -v ./build/libtdjson.so.* ./build/libtdjson_freebsd_amd64.so
+
+      - name: Release artifacts to packages
+        uses: softprops/action-gh-release@v1
+        with:
+          files: build/libtdjson_freebsd_amd64.so

--- a/.github/workflows/build_freebsd.yml
+++ b/.github/workflows/build_freebsd.yml
@@ -26,7 +26,7 @@ jobs:
           run: |
             mkdir ./build
             cmake -DCMAKE_BUILD_TYPE=Release -S ./tdlib -B ./build -G Ninja
-            cmake --build ./build --target tdjson --parallel
+            cmake --build ./build --target tdjson --parallel 2
             strip --strip-all ./build/libtdjson.so.*
             mv -v ./build/libtdjson.so.* ./build/libtdjson_freebsd_amd64.so
 

--- a/.github/workflows/build_freebsd.yml
+++ b/.github/workflows/build_freebsd.yml
@@ -1,4 +1,4 @@
-name: Build and publish tdlibjson linux binaries
+name: Build and publish FreeBSD tdlibjson binaries
 
 on:
   push:
@@ -6,27 +6,6 @@ on:
       - "aiotdlib_*"
 
 jobs:
-  build_linux:
-    name: Build Linux x86_64
-    runs-on: ubuntu-latest
-    steps:
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
-
-      - name: Set up Earthly
-        uses: earthly/actions/setup-earthly@v1
-
-      - name: Check out the repo
-        uses: actions/checkout@v2
-
-      - name: run earthly build
-        run: earthly +build-all-platforms
-
-      - name: release artifacts to packages
-        uses: softprops/action-gh-release@v1
-        with:
-          files: build/libtdjson_linux_amd64.so
-
   build_freebsd:
     name: Build FreeBSD x86_64
     runs-on: macos-12

--- a/.github/workflows/build_freebsd.yml
+++ b/.github/workflows/build_freebsd.yml
@@ -19,7 +19,7 @@ jobs:
         uses: vmactions/freebsd-vm@v0
         with:
           release: 13.1
-          mem: 2048
+          mem: 3072
           prepare: |
             pkg update
             pkg install -y llvm cmake ninja gperf openssl lzlib gperf

--- a/.github/workflows/build_linux.yml
+++ b/.github/workflows/build_linux.yml
@@ -1,0 +1,28 @@
+name: Build and publish Linux tdlibjson binaries
+
+on:
+  push:
+    tags:
+      - "aiotdlib_*"
+
+jobs:
+  build_linux:
+    name: Build Linux x86_64
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Set up Earthly
+        uses: earthly/actions/setup-earthly@v1
+
+      - name: Check out the repo
+        uses: actions/checkout@v2
+
+      - name: run earthly build
+        run: earthly +build-all-platforms
+
+      - name: release artifacts to packages
+        uses: softprops/action-gh-release@v1
+        with:
+          files: build/libtdjson_linux_amd64.so


### PR DESCRIPTION
Since FreeBSD CIs are not supported on GitHub Actions out of the box, this pull request adds support by using [vmactions/freebsd-vm](https://github.com/vmactions/freebsd-vm) (note that this uses macOS runners).

I tested it on https://github.com/zebrapurring/td/actions/runs/3868967922/jobs/6594770693 and as you can see the build completes successfully in around 35 minutes.